### PR TITLE
JS files starting with #! fails esprima parse, skip the first line accordingly

### DIFF
--- a/index.js
+++ b/index.js
@@ -241,11 +241,20 @@ function updateJSFiles(targetPath, version) {
         if (err) return callback(err);
 
         entries.forEach(function(buffer, index) {
-          var updatedSource = hasVersionMetadata(buffer.toString());
+          var bufferText = buffer.toString();
+          var firstLine = bufferText.split("\n")[0];
+          if (firstLine.startsWith("#!")) {
+            //We're busy with a bang file, will not pass esprima. Remove the line and add it later
+            bufferText = bufferText.substr(firstLine.length + 1);
+            firstLine = firstLine + '\n';
+          } else {
+            firstLine = '';
+          }
+          var updatedSource = hasVersionMetadata(bufferText);
 
           if (updatedSource) {
             console.log('applied version metadata update to: ' + files[index]);
-            fs.writeFileSync(files[index], updatedSource);
+            fs.writeFileSync(files[index], bufferText + updatedSource);
           }
         });
 

--- a/index.js
+++ b/index.js
@@ -254,7 +254,7 @@ function updateJSFiles(targetPath, version) {
 
           if (updatedSource) {
             console.log('applied version metadata update to: ' + files[index]);
-            fs.writeFileSync(files[index], bufferText + updatedSource);
+            fs.writeFileSync(files[index], firstLine + updatedSource);
           }
         });
 


### PR DESCRIPTION
In the case of bin js files (used in runnable scripts) the first line is usually the bang operator #!
Such a line will not be parsed by esprima - causing a fault when trying to get the metadata from a file (and stopping the whole process as a result of the exception).

This fixes it - it removes a bang started js file's first line and have the rest of it being parsed.